### PR TITLE
feat(data): adds STCP gtfs data url

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npm start
 - **Transtejo** - agency_key: 'transtejo'
 - **Rodoviária** de Lisboa - agency_key: 'rodoviaria-de-lisboa'
 - **Transportes** Sul do Tejo - agency_key: 'tst'
+- **STCP** - Sociedade de Transportes Colectivos do Porto - agency_key: 'stcp'
 
 ## Examples
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -114,6 +114,17 @@ const gtfsImportConfiguration = {
             url:
                 'https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=4&u=web',
         },
+        {
+            agency_key: 'stcp',
+            exclude: [
+                'fare_attributes',
+                'fare_rules',
+                'transfers',
+                'feed_info',
+            ],
+            url:
+                'https://opendata.porto.digital/dataset/5275c986-592c-43f5-8f87-aabbd4e4f3a4/resource/1f845744-1962-4108-a20c-ac3357d0957b/download/gtfs-stcp.zip',
+        }
     ],
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds STCP (Sociedade de Transportes Colectivos do Porto) GTFS data url, sourced from [here](https://opendata.porto.digital/sv/dataset/horarios-paragens-e-rotas-em-formato-gtfs-stcp/resource/1f845744-1962-4108-a20c-ac3357d0957b)
