### PR TITLE
feat(data): adds Metro do Porto gtfs data url

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ npm start
 - **Transtejo** - agency_key: 'transtejo'
 - **Rodoviária** de Lisboa - agency_key: 'rodoviaria-de-lisboa'
 - **Transportes** Sul do Tejo - agency_key: 'tst'
+- **Metro do Porto** - agency_key: 'metro-porto'
 
 ## Examples
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -114,6 +114,17 @@ const gtfsImportConfiguration = {
             url:
                 'https://www.transporlis.pt/desktopmodules/trp_opendata/ajax/downloadFile.ashx?op=4&u=web',
         },
+        {
+            agency_key: 'metro-porto',
+            exclude: [
+                'fare_attributes',
+                'fare_rules',
+                'transfers',
+                'feed_info',
+            ],
+            url:
+                'https://opendata.porto.digital/dataset/15f22603-a216-492a-ab1c-40b1d8aa2f08/resource/fdaaddbe-4782-4f4e-9a30-98caedce8dc5/download/gtfs_mdp_11_09_2023.zip',
+        },
     ],
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Metro do Porto GTFS data url, sourced from [here](https://opendata.porto.digital/en/dataset/horarios-paragens-e-rotas-em-formato-gtfs/resource/fdaaddbe-4782-4f4e-9a30-98caedce8dc5)
